### PR TITLE
add NoPersist option

### DIFF
--- a/jar.go
+++ b/jar.go
@@ -67,6 +67,11 @@ type Options struct {
 	// Filename holds the file to use for storage of the cookies.
 	// If it is empty, the value of DefaultCookieFile will be used.
 	Filename string
+
+	// NoPersist specifies whether no persistence should be used
+	// (useful for tests). If this is true, the value of Filename will be
+	// ignored.
+	NoPersist bool
 }
 
 // Jar implements the http.CookieJar interface from the net/http package.
@@ -106,11 +111,13 @@ func newAtTime(o *Options, now time.Time) (*Jar, error) {
 	if jar.psList = o.PublicSuffixList; jar.psList == nil {
 		jar.psList = publicsuffix.List
 	}
-	if jar.filename = o.Filename; jar.filename == "" {
-		jar.filename = DefaultCookieFile()
-	}
-	if err := jar.load(); err != nil {
-		return nil, errgo.Notef(err, "cannot load cookies")
+	if !o.NoPersist {
+		if jar.filename = o.Filename; jar.filename == "" {
+			jar.filename = DefaultCookieFile()
+		}
+		if err := jar.load(); err != nil {
+			return nil, errgo.Notef(err, "cannot load cookies")
+		}
 	}
 	jar.deleteExpired(now)
 	return jar, nil

--- a/serialize.go
+++ b/serialize.go
@@ -22,6 +22,9 @@ import (
 // Before the file is written, it reads any cookies that
 // have been stored from it and merges them into j.
 func (j *Jar) Save() error {
+	if j.filename == "" {
+		return nil
+	}
 	return j.save(time.Now())
 }
 


### PR DESCRIPTION
Perhaps a little odd for a "persistent" cookiejar
to have an option to avoid persistence,
but useful for tests.