### PR TITLE
Feature/cookie filter

### DIFF
--- a/jar.go
+++ b/jar.go
@@ -603,7 +603,7 @@ func (cff CookieFilterFunc) IsPersistent(c *http.Cookie) bool {
 // Well-known FilterFuncs
 var (
 	DefaultFilter = CookieFilterFunc(func(c *http.Cookie) bool {
-		return c.MaxAge == 0 && !c.Expires.IsZero()
+		return c.MaxAge != 0 || !c.Expires.IsZero()
 	})
 
 	AnyFilter = CookieFilterFunc(func(c *http.Cookie) bool {

--- a/jar.go
+++ b/jar.go
@@ -164,6 +164,7 @@ type entry struct {
 	HostOnly   bool
 	Expires    time.Time
 	Creation   time.Time
+	MaxAge     int
 	LastAccess time.Time
 
 	// Updated records when the cookie was updated.
@@ -271,11 +272,11 @@ func (j *Jar) Cookies(u *url.URL) (cookies []*http.Cookie) {
 // cookies is like Cookies but takes the current time as a parameter.
 func (j *Jar) cookies(u *url.URL, now time.Time) (cookies []*http.Cookie) {
 	if u.Scheme != "http" && u.Scheme != "https" {
-		return
+		return cookies
 	}
 	host, err := canonicalHost(u.Host)
 	if err != nil {
-		return
+		return cookies
 	}
 	key := jarKey(host, j.psList)
 
@@ -284,7 +285,7 @@ func (j *Jar) cookies(u *url.URL, now time.Time) (cookies []*http.Cookie) {
 
 	submap := j.entries[key]
 	if submap == nil {
-		return
+		return cookies
 	}
 
 	https := u.Scheme == "https"
@@ -604,6 +605,7 @@ var (
 	DefaultFilter = CookieFilterFunc(func(c *http.Cookie) bool {
 		return c.MaxAge == 0 && !c.Expires.IsZero()
 	})
+
 	AnyFilter = CookieFilterFunc(func(c *http.Cookie) bool {
 		return true
 	})
@@ -621,6 +623,7 @@ var (
 // A malformed c.Domain will result in an error.
 func (j *Jar) newEntry(c *http.Cookie, now time.Time, defPath, host string) (e entry, err error) {
 	e.Name = c.Name
+	e.MaxAge = c.MaxAge
 	if c.Path == "" || c.Path[0] != '/' {
 		e.Path = defPath
 	} else {

--- a/serialize.go
+++ b/serialize.go
@@ -138,7 +138,16 @@ func (j *Jar) allPersistentEntries() []entry {
 	var entries []entry
 	for _, submap := range j.entries {
 		for _, e := range submap {
-			if j.filter.IsPersistent(&http.Cookie{Name: e.Name, Value: e.Value}) {
+			if j.filter.IsPersistent(&http.Cookie{
+				Domain:   e.Domain,
+				Expires:  e.Expires,
+				HttpOnly: e.HttpOnly,
+				MaxAge:   e.MaxAge,
+				Name:     e.Name,
+				Path:     e.Path,
+				Secure:   e.Secure,
+				Value:    e.Value,
+			}) {
 				entries = append(entries, e)
 			}
 		}

--- a/serialize.go
+++ b/serialize.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"io"
 	"log"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
@@ -137,7 +138,7 @@ func (j *Jar) allPersistentEntries() []entry {
 	var entries []entry
 	for _, submap := range j.entries {
 		for _, e := range submap {
-			if e.Persistent {
+			if j.filter.IsPersistent(&http.Cookie{Name: e.Name, Value: e.Value}) {
 				entries = append(entries, e)
 			}
 		}


### PR DESCRIPTION
This should help address #29, as well as pretty much any other possible decisions clients may want to make about which cookies should be persisted.

It has changed the code layout quite a bit, and will persist more on disk (so that decisions can continue to be made based on original input data) but should be logically equivalent and extra flexible.