### PR TITLE
Add Option parameter to enable persistence of session cookies

### DIFF
--- a/serialize.go
+++ b/serialize.go
@@ -35,7 +35,7 @@ func (j *Jar) MarshalJSON() ([]byte, error) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 	// Marshaling entries can never fail.
-	data, _ := json.Marshal(j.allPersistentEntries())
+	data, _ := json.Marshal(j.allEntriesToPersist())
 	return data, nil
 }
 
@@ -124,20 +124,20 @@ func (j *Jar) mergeFrom(r io.Reader) error {
 // as a JSON array.
 func (j *Jar) writeTo(w io.Writer) error {
 	encoder := json.NewEncoder(w)
-	entries := j.allPersistentEntries()
+	entries := j.allEntriesToPersist()
 	if err := encoder.Encode(entries); err != nil {
 		return err
 	}
 	return nil
 }
 
-// allPersistentEntries returns all the entries in the jar, sorted by primarly by canonical host
+// allEntriesToPersist returns all the entries in the jar, sorted by primarly by canonical host
 // name and secondarily by path length.
-func (j *Jar) allPersistentEntries() []entry {
+func (j *Jar) allEntriesToPersist() []entry {
 	var entries []entry
 	for _, submap := range j.entries {
 		for _, e := range submap {
-			if e.Persistent {
+			if j.persistSessionCookies || e.Persistent {
 				entries = append(entries, e)
 			}
 		}


### PR DESCRIPTION
Fixes #29 

This PR adds a new option, `PersistSessionCookies` to the `Option` struct. This allows users to persist both cookies with an expiry time, and those without. By default session cookies are not persisted (which matches current behavior), nor will any session cookies that appear in the serialized cookies on disk be loaded into the jar.

This PR is motivated by usage of the library within command line tools. In the motivating cases, the user might execute a series of separate commands in their terminal. Each command runs as a separate OS process, so they do not share memory, but they still span a logical session with a web API. Allowing session cookies to be persisted allows that session to continue over the sequence of commands.